### PR TITLE
Add Mass Assembler support for Interface Terminal

### DIFF
--- a/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
@@ -27,13 +27,10 @@ public class MassAssemblerTracker {
         this.id = autoBase--;
         this.server = store.getPatternInventory();
         this.client = new AppEngInternalInventory(null, this.server.getSlots());
-        // Highlight button points to the controller
         this.pos = core.getPos();
         this.dim = core.getWorld().provider.getDimension();
-        BlockPos corePos = core.getPos();
-        long coreSort = ((long) corePos.getZ() << 24) ^ ((long) corePos.getX() << 8) ^ corePos.getY();
+        long coreSort = ((long) pos.getZ() << 24) ^ ((long) pos.getX() << 8) ^ pos.getY();
         this.sortBy = (coreSort << 8) | storeIndex;
-        // Use custom name if set via Cutting Knife, otherwise use block translation key
         if (core instanceof ICustomNameObject && ((ICustomNameObject) core).hasCustomInventoryName()) {
             this.unlocalizedName = ((ICustomNameObject) core).getCustomInventoryName();
         } else {
@@ -42,19 +39,6 @@ public class MassAssemblerTracker {
             ItemStack storeStack = new ItemStack(storeBlock, 1, storeBlock.getMetaFromState(storeState));
             this.unlocalizedName = storeStack.getItem().getTranslationKey(storeStack);
         }
-        // 36 slots = 4 rows of 9, so numUpgrades = 3 (base 1 row + 3 extra rows)
         this.numUpgrades = 3;
-    }
-
-    public boolean isDifferent(int slot) {
-        ItemStack serverStack = server.getStackInSlot(slot);
-        ItemStack clientStack = client.getStackInSlot(slot);
-        if (serverStack.isEmpty() && clientStack.isEmpty()) {
-            return false;
-        }
-        if (serverStack.isEmpty() || clientStack.isEmpty()) {
-            return true;
-        }
-        return !ItemStack.areItemStacksEqual(serverStack, clientStack);
     }
 }

--- a/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
@@ -1,0 +1,60 @@
+package net.teamfruit.lazyae2patch;
+
+import appeng.helpers.ICustomNameObject;
+import appeng.tile.inventory.AppEngInternalInventory;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerPatternStore;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.items.IItemHandler;
+
+public class MassAssemblerTracker {
+
+    private static long autoBase = Long.MAX_VALUE;
+
+    public final long id;
+    public final long sortBy;
+    public final String unlocalizedName;
+    public final IItemHandler server;
+    public final AppEngInternalInventory client;
+    public final BlockPos pos;
+    public final int dim;
+    public final int numUpgrades;
+
+    public MassAssemblerTracker(TileBigAssemblerPatternStore store, TileBigAssemblerCore core, int storeIndex) {
+        this.id = autoBase--;
+        this.server = store.getPatternInventory();
+        this.client = new AppEngInternalInventory(null, this.server.getSlots());
+        // Highlight button points to the controller
+        this.pos = core.getPos();
+        this.dim = core.getWorld().provider.getDimension();
+        BlockPos corePos = core.getPos();
+        long coreSort = ((long) corePos.getZ() << 24) ^ ((long) corePos.getX() << 8) ^ corePos.getY();
+        this.sortBy = (coreSort << 8) | storeIndex;
+        // Use custom name if set via Cutting Knife, otherwise use block translation key
+        if (core instanceof ICustomNameObject && ((ICustomNameObject) core).hasCustomInventoryName()) {
+            this.unlocalizedName = ((ICustomNameObject) core).getCustomInventoryName();
+        } else {
+            IBlockState storeState = store.getWorld().getBlockState(store.getPos());
+            Block storeBlock = storeState.getBlock();
+            ItemStack storeStack = new ItemStack(storeBlock, 1, storeBlock.getMetaFromState(storeState));
+            this.unlocalizedName = storeStack.getItem().getTranslationKey(storeStack);
+        }
+        // 36 slots = 4 rows of 9, so numUpgrades = 3 (base 1 row + 3 extra rows)
+        this.numUpgrades = 3;
+    }
+
+    public boolean isDifferent(int slot) {
+        ItemStack serverStack = server.getStackInSlot(slot);
+        ItemStack clientStack = client.getStackInSlot(slot);
+        if (serverStack.isEmpty() && clientStack.isEmpty()) {
+            return false;
+        }
+        if (serverStack.isEmpty() || clientStack.isEmpty()) {
+            return true;
+        }
+        return !ItemStack.areItemStacksEqual(serverStack, clientStack);
+    }
+}

--- a/src/main/java/net/teamfruit/lazyae2patch/PatternSlotFilter.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/PatternSlotFilter.java
@@ -1,0 +1,21 @@
+package net.teamfruit.lazyae2patch;
+
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.util.inv.filter.IAEItemFilter;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+public class PatternSlotFilter implements IAEItemFilter {
+
+    public static final PatternSlotFilter INSTANCE = new PatternSlotFilter();
+
+    @Override
+    public boolean allowExtract(IItemHandler inv, int slot, int amount) {
+        return true;
+    }
+
+    @Override
+    public boolean allowInsert(IItemHandler inv, int slot, ItemStack stack) {
+        return !stack.isEmpty() && stack.getItem() instanceof ICraftingPatternItem;
+    }
+}

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinBlockBigAssembler.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinBlockBigAssembler.java
@@ -1,0 +1,46 @@
+package net.teamfruit.lazyae2patch.mixins;
+
+import appeng.api.util.AEPartLocation;
+import appeng.core.sync.GuiBridge;
+import appeng.items.tools.quartz.ToolQuartzCuttingKnife;
+import appeng.util.Platform;
+import io.github.phantamanta44.libnine.component.multiblock.MultiBlockCore;
+import io.github.phantamanta44.threng.block.BlockBigAssembler;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
+import io.github.phantamanta44.threng.tile.base.IBigAssemblerUnit;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockBigAssembler.class)
+public abstract class MixinBlockBigAssembler {
+
+    @Inject(method = "onBlockActivated", at = @At("HEAD"), cancellable = true)
+    private void lazyae2patch$onCuttingKnife(World world, BlockPos pos, IBlockState state, EntityPlayer player,
+                                              EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ,
+                                              CallbackInfoReturnable<Boolean> cir) {
+        ItemStack held = player.getHeldItem(hand);
+        if (held.getItem() instanceof ToolQuartzCuttingKnife) {
+            TileEntity te = world.getTileEntity(pos);
+            if (te instanceof IBigAssemblerUnit) {
+                MultiBlockCore<IBigAssemblerUnit> core = ((IBigAssemblerUnit) te).getMultiBlockConnection().getCore();
+                if (core != null && core.getUnit().isActive()) {
+                    TileBigAssemblerCore coreTE = (TileBigAssemblerCore) core.getUnit();
+                    if (!world.isRemote) {
+                        Platform.openGUI(player, coreTE, AEPartLocation.fromFacing(facing), GuiBridge.GUI_RENAMER);
+                    }
+                    cir.setReturnValue(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
@@ -1,0 +1,309 @@
+package net.teamfruit.lazyae2patch.mixins;
+
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.security.IActionHost;
+import appeng.container.AEBaseContainer;
+import appeng.container.implementations.ContainerInterfaceTerminal;
+import appeng.helpers.InventoryAction;
+import appeng.util.InventoryAdaptor;
+import appeng.util.Platform;
+import appeng.util.helpers.ItemHandlerUtil;
+import appeng.util.inv.AdaptorItemHandler;
+import appeng.util.inv.WrapperCursorItemHandler;
+import appeng.util.inv.WrapperFilteredItemHandler;
+import appeng.util.inv.WrapperRangeItemHandler;
+import appeng.util.inv.filter.IAEItemFilter;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerPatternStore;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.teamfruit.lazyae2patch.MassAssemblerTracker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static appeng.helpers.ItemStackHelper.stackWriteToNBT;
+
+@Mixin(ContainerInterfaceTerminal.class)
+public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
+
+    @Shadow(remap = false)
+    private IGrid grid;
+
+    @Shadow(remap = false)
+    private NBTTagCompound data;
+
+    private MixinContainerInterfaceTerminal() {
+        super(null, null, null);
+    }
+
+    @Unique
+    private final Map<TileBigAssemblerPatternStore, MassAssemblerTracker> lazyae2patch$maTrackers = new HashMap<>();
+
+    @Unique
+    private final Map<Long, MassAssemblerTracker> lazyae2patch$maById = new HashMap<>();
+
+    /**
+     * Redirect Map.size() on diList to force a full regen when Mass Assembler state changes.
+     * This is the only Map.size() call in detectAndSendChanges, on the diList field.
+     */
+    @Redirect(method = "detectAndSendChanges",
+            at = @At(value = "INVOKE", target = "Ljava/util/Map;size()I", remap = false))
+    private int lazyae2patch$onDiListSize(Map<?, ?> map) {
+        if (lazyae2patch$maNeedsUpdate()) {
+            return -1;
+        }
+        return map.size();
+    }
+
+    /**
+     * After regenList rebuilds all interface entries, also add Mass Assembler pattern store entries.
+     */
+    @Inject(method = "regenList", at = @At("TAIL"), remap = false)
+    private void lazyae2patch$onRegenList(NBTTagCompound data, CallbackInfo ci) {
+        lazyae2patch$maTrackers.clear();
+        lazyae2patch$maById.clear();
+
+        if (this.grid == null) return;
+
+        final IActionHost host = this.getActionHost();
+        if (host == null) return;
+        final IGridNode agn = host.getActionableNode();
+        if (agn == null || !agn.isActive()) return;
+
+        for (final IGridNode gn : this.grid.getMachines(TileBigAssemblerCore.class)) {
+            if (!gn.isActive()) continue;
+            final TileBigAssemblerCore core = (TileBigAssemblerCore) gn.getMachine();
+            if (!core.isActive()) continue;
+
+            final List<TileBigAssemblerPatternStore> stores = core.getPatternStores();
+            for (int i = 0; i < stores.size(); i++) {
+                final TileBigAssemblerPatternStore store = stores.get(i);
+                final MassAssemblerTracker tracker = new MassAssemblerTracker(store, core, i);
+                lazyae2patch$maTrackers.put(store, tracker);
+                lazyae2patch$maById.put(tracker.id, tracker);
+                lazyae2patch$writeTrackerData(data, tracker, 0, tracker.server.getSlots());
+            }
+        }
+    }
+
+    /**
+     * Handle slot interactions for Mass Assembler entries in the Interface Terminal.
+     */
+    @Inject(method = "doAction", at = @At("HEAD"), cancellable = true, remap = false)
+    private void lazyae2patch$onDoAction(EntityPlayerMP player, InventoryAction action, int slot, long id, CallbackInfo ci) {
+        final MassAssemblerTracker tracker = lazyae2patch$maById.get(id);
+        if (tracker == null) return;
+
+        lazyae2patch$handleMaAction(player, action, slot, tracker);
+        this.detectAndSendChanges();
+        ci.cancel();
+    }
+
+    @Unique
+    private void lazyae2patch$handleMaAction(EntityPlayerMP player, InventoryAction action, int slot, MassAssemblerTracker tracker) {
+        final ItemStack is = tracker.server.getStackInSlot(slot);
+        final boolean hasItemInHand = !player.inventory.getItemStack().isEmpty();
+
+        final InventoryAdaptor playerHand = new AdaptorItemHandler(new WrapperCursorItemHandler(player.inventory));
+
+        final IItemHandler theSlot = new WrapperFilteredItemHandler(
+                new WrapperRangeItemHandler(tracker.server, slot, slot + 1),
+                new LazyAE2PatternSlotFilter());
+        final InventoryAdaptor interfaceSlot = new AdaptorItemHandler(theSlot);
+
+        final IItemHandler interfaceHandler = tracker.server;
+
+        switch (action) {
+            case PICKUP_OR_SET_DOWN:
+                if (hasItemInHand) {
+                    boolean canInsert = true;
+                    for (int s = 0; s < interfaceHandler.getSlots(); s++) {
+                        if (Platform.itemComparisons().isSameItem(interfaceHandler.getStackInSlot(s), player.inventory.getItemStack())) {
+                            canInsert = false;
+                            break;
+                        }
+                    }
+                    if (canInsert) {
+                        ItemStack inSlot = theSlot.getStackInSlot(0);
+                        if (inSlot.isEmpty()) {
+                            player.inventory.setItemStack(interfaceSlot.addItems(player.inventory.getItemStack()));
+                        } else {
+                            inSlot = inSlot.copy();
+                            final ItemStack inHand = player.inventory.getItemStack().copy();
+                            ItemHandlerUtil.setStackInSlot(theSlot, 0, ItemStack.EMPTY);
+                            player.inventory.setItemStack(ItemStack.EMPTY);
+                            player.inventory.setItemStack(interfaceSlot.addItems(inHand.copy()));
+                            if (player.inventory.getItemStack().isEmpty()) {
+                                player.inventory.setItemStack(inSlot);
+                            } else {
+                                player.inventory.setItemStack(inHand);
+                                ItemHandlerUtil.setStackInSlot(theSlot, 0, inSlot);
+                            }
+                        }
+                    }
+                } else {
+                    ItemHandlerUtil.setStackInSlot(theSlot, 0, playerHand.addItems(theSlot.getStackInSlot(0)));
+                }
+                break;
+
+            case SPLIT_OR_PLACE_SINGLE:
+                if (hasItemInHand) {
+                    boolean canInsert = true;
+                    for (int s = 0; s < interfaceHandler.getSlots(); s++) {
+                        if (Platform.itemComparisons().isSameItem(interfaceHandler.getStackInSlot(s), player.inventory.getItemStack())) {
+                            canInsert = false;
+                            break;
+                        }
+                    }
+                    if (canInsert) {
+                        ItemStack extra = playerHand.removeItems(1, ItemStack.EMPTY, null);
+                        if (!extra.isEmpty() && !interfaceSlot.containsItems()) {
+                            extra = interfaceSlot.addItems(extra);
+                        }
+                        if (!extra.isEmpty()) {
+                            playerHand.addItems(extra);
+                        }
+                    }
+                } else if (!is.isEmpty()) {
+                    ItemStack extra = interfaceSlot.removeItems((is.getCount() + 1) / 2, ItemStack.EMPTY, null);
+                    if (!extra.isEmpty()) {
+                        extra = playerHand.addItems(extra);
+                    }
+                    if (!extra.isEmpty()) {
+                        interfaceSlot.addItems(extra);
+                    }
+                }
+                break;
+
+            case SHIFT_CLICK: {
+                final InventoryAdaptor playerInv = InventoryAdaptor.getAdaptor(player);
+                ItemHandlerUtil.setStackInSlot(theSlot, 0, playerInv.addItems(theSlot.getStackInSlot(0)));
+                break;
+            }
+
+            case MOVE_REGION: {
+                final InventoryAdaptor playerInvAd = InventoryAdaptor.getAdaptor(player);
+                for (int x = 0; x < tracker.server.getSlots(); x++) {
+                    ItemHandlerUtil.setStackInSlot(tracker.server, x, playerInvAd.addItems(tracker.server.getStackInSlot(x)));
+                }
+                break;
+            }
+
+            case CREATIVE_DUPLICATE:
+                if (player.capabilities.isCreativeMode && !hasItemInHand) {
+                    player.inventory.setItemStack(is.isEmpty() ? ItemStack.EMPTY : is.copy());
+                }
+                break;
+
+            case PLACE_SINGLE: {
+                final net.minecraft.inventory.Slot playerSlot;
+                try {
+                    playerSlot = this.inventorySlots.get(slot);
+                } catch (IndexOutOfBoundsException ignored) {
+                    return;
+                }
+                if (!(playerSlot instanceof appeng.container.slot.AppEngSlot)) return;
+                if (!((appeng.container.slot.AppEngSlot) playerSlot).isPlayerSide() || !playerSlot.getHasStack())
+                    return;
+                ItemStack itemStack = playerSlot.getStack();
+                if (!itemStack.isEmpty()) {
+                    IItemHandler handler = new WrapperFilteredItemHandler(
+                            new WrapperRangeItemHandler(tracker.server, 0, tracker.server.getSlots()),
+                            new LazyAE2PatternSlotFilter());
+                    playerSlot.putStack(ItemHandlerHelper.insertItem(handler, itemStack, false));
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        this.updateHeld(player);
+    }
+
+    @Unique
+    private boolean lazyae2patch$maNeedsUpdate() {
+        if (this.grid == null) return false;
+
+        final IActionHost host = this.getActionHost();
+        if (host == null) return false;
+        final IGridNode agn = host.getActionableNode();
+        if (agn == null || !agn.isActive()) return false;
+
+        int total = 0;
+        for (final IGridNode gn : this.grid.getMachines(TileBigAssemblerCore.class)) {
+            if (!gn.isActive()) continue;
+            final TileBigAssemblerCore core = (TileBigAssemblerCore) gn.getMachine();
+            if (!core.isActive()) continue;
+            for (final TileBigAssemblerPatternStore store : core.getPatternStores()) {
+                if (!lazyae2patch$maTrackers.containsKey(store)) return true;
+                total++;
+            }
+        }
+
+        if (total != lazyae2patch$maTrackers.size()) return true;
+
+        for (final MassAssemblerTracker tracker : lazyae2patch$maTrackers.values()) {
+            for (int x = 0; x < tracker.server.getSlots(); x++) {
+                if (tracker.isDifferent(x)) return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Unique
+    private void lazyae2patch$writeTrackerData(NBTTagCompound data, MassAssemblerTracker tracker, int offset, int length) {
+        final String name = "=" + Long.toString(tracker.id, Character.MAX_RADIX);
+        final NBTTagCompound tag = data.getCompoundTag(name);
+
+        if (tag.isEmpty()) {
+            tag.setLong("sortBy", tracker.sortBy);
+            tag.setString("un", tracker.unlocalizedName);
+            tag.setTag("pos", NBTUtil.createPosTag(tracker.pos));
+            tag.setInteger("dim", tracker.dim);
+            tag.setInteger("numUpgrades", tracker.numUpgrades);
+        }
+
+        for (int x = 0; x < length; x++) {
+            final NBTTagCompound itemNBT = new NBTTagCompound();
+            final ItemStack is = tracker.server.getStackInSlot(x + offset);
+            tracker.client.setStackInSlot(x + offset, is.isEmpty() ? ItemStack.EMPTY : is.copy());
+            if (!is.isEmpty()) {
+                stackWriteToNBT(is, itemNBT);
+            }
+            tag.setTag(Integer.toString(x + offset), itemNBT);
+        }
+
+        data.setTag(name, tag);
+    }
+
+    @Unique
+    private static class LazyAE2PatternSlotFilter implements IAEItemFilter {
+        @Override
+        public boolean allowExtract(IItemHandler inv, int slot, int amount) {
+            return true;
+        }
+
+        @Override
+        public boolean allowInsert(IItemHandler inv, int slot, ItemStack stack) {
+            return !stack.isEmpty() && stack.getItem() instanceof ICraftingPatternItem;
+        }
+    }
+}

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
@@ -1,6 +1,5 @@
 package net.teamfruit.lazyae2patch.mixins;
 
-import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.IActionHost;
@@ -14,7 +13,6 @@ import appeng.util.inv.AdaptorItemHandler;
 import appeng.util.inv.WrapperCursorItemHandler;
 import appeng.util.inv.WrapperFilteredItemHandler;
 import appeng.util.inv.WrapperRangeItemHandler;
-import appeng.util.inv.filter.IAEItemFilter;
 import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
 import io.github.phantamanta44.threng.tile.TileBigAssemblerPatternStore;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -24,6 +22,7 @@ import net.minecraft.nbt.NBTUtil;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.teamfruit.lazyae2patch.MassAssemblerTracker;
+import net.teamfruit.lazyae2patch.PatternSlotFilter;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -46,6 +45,9 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
 
     @Shadow(remap = false)
     private NBTTagCompound data;
+
+    @Shadow(remap = false)
+    private boolean isDifferent(ItemStack a, ItemStack b) { throw new AssertionError(); }
 
     private MixinContainerInterfaceTerminal() {
         super(null, null, null);
@@ -123,7 +125,7 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
 
         final IItemHandler theSlot = new WrapperFilteredItemHandler(
                 new WrapperRangeItemHandler(tracker.server, slot, slot + 1),
-                new LazyAE2PatternSlotFilter());
+                PatternSlotFilter.INSTANCE);
         final InventoryAdaptor interfaceSlot = new AdaptorItemHandler(theSlot);
 
         final IItemHandler interfaceHandler = tracker.server;
@@ -224,7 +226,7 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
                 if (!itemStack.isEmpty()) {
                     IItemHandler handler = new WrapperFilteredItemHandler(
                             new WrapperRangeItemHandler(tracker.server, 0, tracker.server.getSlots()),
-                            new LazyAE2PatternSlotFilter());
+                            PatternSlotFilter.INSTANCE);
                     playerSlot.putStack(ItemHandlerHelper.insertItem(handler, itemStack, false));
                 }
                 break;
@@ -261,7 +263,7 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
 
         for (final MassAssemblerTracker tracker : lazyae2patch$maTrackers.values()) {
             for (int x = 0; x < tracker.server.getSlots(); x++) {
-                if (tracker.isDifferent(x)) return true;
+                if (this.isDifferent(tracker.server.getStackInSlot(x), tracker.client.getStackInSlot(x))) return true;
             }
         }
 
@@ -294,16 +296,4 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
         data.setTag(name, tag);
     }
 
-    @Unique
-    private static class LazyAE2PatternSlotFilter implements IAEItemFilter {
-        @Override
-        public boolean allowExtract(IItemHandler inv, int slot, int amount) {
-            return true;
-        }
-
-        @Override
-        public boolean allowInsert(IItemHandler inv, int slot, ItemStack stack) {
-            return !stack.isEmpty() && stack.getItem() instanceof ICraftingPatternItem;
-        }
-    }
 }

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinTileBigAssemblerCore.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinTileBigAssemblerCore.java
@@ -1,0 +1,50 @@
+package net.teamfruit.lazyae2patch.mixins;
+
+import appeng.helpers.ICustomNameObject;
+import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TileBigAssemblerCore.class)
+public abstract class MixinTileBigAssemblerCore implements ICustomNameObject {
+
+    @Unique
+    private String lazyae2patch$customName;
+
+    @Override
+    public String getCustomInventoryName() {
+        return lazyae2patch$customName != null ? lazyae2patch$customName : "";
+    }
+
+    @Override
+    public boolean hasCustomInventoryName() {
+        return lazyae2patch$customName != null && !lazyae2patch$customName.isEmpty();
+    }
+
+    @Override
+    public void setCustomName(String name) {
+        lazyae2patch$customName = name;
+    }
+
+    // Use both MCP and SRG names to work in dev and production environments
+    @Inject(method = {"writeToNBT", "func_189515_b"}, at = @At("TAIL"), remap = false)
+    private void lazyae2patch$onWriteNBT(NBTTagCompound data, CallbackInfoReturnable<NBTTagCompound> cir) {
+        if (lazyae2patch$customName != null && !lazyae2patch$customName.isEmpty()) {
+            data.setString("customName", lazyae2patch$customName);
+        }
+    }
+
+    @Inject(method = {"readFromNBT", "func_145839_a"}, at = @At("TAIL"), remap = false)
+    private void lazyae2patch$onReadNBT(NBTTagCompound data, CallbackInfo ci) {
+        if (data.hasKey("customName")) {
+            lazyae2patch$customName = data.getString("customName");
+        } else {
+            lazyae2patch$customName = null;
+        }
+    }
+}

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinTileBigAssemblerCore.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinTileBigAssemblerCore.java
@@ -2,16 +2,14 @@ package net.teamfruit.lazyae2patch.mixins;
 
 import appeng.helpers.ICustomNameObject;
 import io.github.phantamanta44.threng.tile.TileBigAssemblerCore;
+import io.github.phantamanta44.threng.tile.base.TileAENetworked;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(TileBigAssemblerCore.class)
-public abstract class MixinTileBigAssemblerCore implements ICustomNameObject {
+public abstract class MixinTileBigAssemblerCore extends TileAENetworked implements ICustomNameObject {
 
     @Unique
     private String lazyae2patch$customName;
@@ -29,20 +27,23 @@ public abstract class MixinTileBigAssemblerCore implements ICustomNameObject {
     @Override
     public void setCustomName(String name) {
         lazyae2patch$customName = name;
+        ((TileEntity) (Object) this).markDirty();
     }
 
-    // Use both MCP and SRG names to work in dev and production environments
-    @Inject(method = {"writeToNBT", "func_189515_b"}, at = @At("TAIL"), remap = false)
-    private void lazyae2patch$onWriteNBT(NBTTagCompound data, CallbackInfoReturnable<NBTTagCompound> cir) {
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+        compound = super.writeToNBT(compound);
         if (lazyae2patch$customName != null && !lazyae2patch$customName.isEmpty()) {
-            data.setString("customName", lazyae2patch$customName);
+            compound.setString("customName", lazyae2patch$customName);
         }
+        return compound;
     }
 
-    @Inject(method = {"readFromNBT", "func_145839_a"}, at = @At("TAIL"), remap = false)
-    private void lazyae2patch$onReadNBT(NBTTagCompound data, CallbackInfo ci) {
-        if (data.hasKey("customName")) {
-            lazyae2patch$customName = data.getString("customName");
+    @Override
+    public void readFromNBT(NBTTagCompound compound) {
+        super.readFromNBT(compound);
+        if (compound.hasKey("customName")) {
+            lazyae2patch$customName = compound.getString("customName");
         } else {
             lazyae2patch$customName = null;
         }

--- a/src/main/resources/mixins.lazyae2patch.json
+++ b/src/main/resources/mixins.lazyae2patch.json
@@ -1,19 +1,19 @@
 {
-  "required": true,
   "package": "net.teamfruit.lazyae2patch.mixins",
+  "refmap": "mixins.lazyae2patch.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "MixinPacketInventoryAction"
-  ],
-  "server": [
+    "MixinPacketInventoryAction",
+    "MixinContainerInterfaceTerminal",
+    "MixinTileBigAssemblerCore",
+    "MixinBlockBigAssembler"
   ],
   "client": [
     "MixinContainerTile",
     "MixinInventoryRequest",
     "MixinGuiLevelMaintainer"
   ],
-  "injectors": {
-    "defaultRequire": 1
-  },
-  "minVersion": "0.8"
+  "server": []
 }


### PR DESCRIPTION
- Interface Terminal integration
	- Mass Assembler Pattern Providers now appear in the Interface Terminal.
    - You can view, insert, and remove patterns directly from the Interface Terminal without opening the Mass Assembler GUI.
- Cutting Knife renaming
	- Right-clicking any part of a Mass Assembler with a Cutting Knife opens the renamer GUI.
    - The custom name is displayed as the group name in the Interface Terminal.