### PR TITLE
Fix MA interface terminal integration issues

### DIFF
--- a/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/MassAssemblerTracker.java
@@ -31,14 +31,18 @@ public class MassAssemblerTracker {
         this.dim = core.getWorld().provider.getDimension();
         long coreSort = ((long) pos.getZ() << 24) ^ ((long) pos.getX() << 8) ^ pos.getY();
         this.sortBy = (coreSort << 8) | storeIndex;
-        if (core instanceof ICustomNameObject && ((ICustomNameObject) core).hasCustomInventoryName()) {
-            this.unlocalizedName = ((ICustomNameObject) core).getCustomInventoryName();
-        } else {
-            IBlockState storeState = store.getWorld().getBlockState(store.getPos());
-            Block storeBlock = storeState.getBlock();
-            ItemStack storeStack = new ItemStack(storeBlock, 1, storeBlock.getMetaFromState(storeState));
-            this.unlocalizedName = storeStack.getItem().getTranslationKey(storeStack);
-        }
+        this.unlocalizedName = getDisplayName(store, core);
         this.numUpgrades = 3;
+    }
+
+    public static String getDisplayName(TileBigAssemblerPatternStore store, TileBigAssemblerCore core) {
+        if (core instanceof ICustomNameObject && ((ICustomNameObject) core).hasCustomInventoryName()) {
+            return ((ICustomNameObject) core).getCustomInventoryName();
+        }
+
+        IBlockState storeState = store.getWorld().getBlockState(store.getPos());
+        Block storeBlock = storeState.getBlock();
+        ItemStack storeStack = new ItemStack(storeBlock, 1, storeBlock.getMetaFromState(storeState));
+        return storeStack.getItem().getTranslationKey(storeStack);
     }
 }

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
@@ -254,7 +254,9 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
             final TileBigAssemblerCore core = (TileBigAssemblerCore) gn.getMachine();
             if (!core.isActive()) continue;
             for (final TileBigAssemblerPatternStore store : core.getPatternStores()) {
-                if (!lazyae2patch$maTrackers.containsKey(store)) return true;
+                final MassAssemblerTracker tracker = lazyae2patch$maTrackers.get(store);
+                if (tracker == null) return true;
+                if (!tracker.unlocalizedName.equals(MassAssemblerTracker.getDisplayName(store, core))) return true;
                 total++;
             }
         }

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinContainerInterfaceTerminal.java
@@ -241,12 +241,12 @@ public abstract class MixinContainerInterfaceTerminal extends AEBaseContainer {
 
     @Unique
     private boolean lazyae2patch$maNeedsUpdate() {
-        if (this.grid == null) return false;
+        if (this.grid == null) return !lazyae2patch$maTrackers.isEmpty();
 
         final IActionHost host = this.getActionHost();
-        if (host == null) return false;
+        if (host == null) return !lazyae2patch$maTrackers.isEmpty();
         final IGridNode agn = host.getActionableNode();
-        if (agn == null || !agn.isActive()) return false;
+        if (agn == null || !agn.isActive()) return !lazyae2patch$maTrackers.isEmpty();
 
         int total = 0;
         for (final IGridNode gn : this.grid.getMachines(TileBigAssemblerCore.class)) {


### PR DESCRIPTION
- ネットワーク内にInterface TerminalにリストされるものがMAしか存在しない場合、Interface Terminalを開いている間にInterface Terminalがネットワークから切断されても、リストが更新されずMAを操作できる問題を修正
- Interface Terminalを開いている間にMAがリネームされた場合、反映されずに古い名前を表示し続ける問題を修正