### PR TITLE
Fix crash when Mass Assembler patterns exceed 16 slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ local.properties
 run/
 
 logs/
+
+### Claude Code ###
+
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.2
+- Fix crash when Mass Assembler patterns exceed the 4×4 (16-slot) processing grid hardcoded in AE2-UEL
+
+* * *
+
 # v1.2.1
 - Fix upgrade slot calculation based on server slots instead of hardcoded value
 - Add validation to skip Mass Assemblers that have no pattern inventory slots

--- a/buildscript.properties
+++ b/buildscript.properties
@@ -16,7 +16,7 @@ modGroup = net.teamfruit.lazyae2patch
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 1.2.1
+modVersion = 1.2.2
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = false

--- a/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinInventoryCrafting.java
+++ b/src/main/java/net/teamfruit/lazyae2patch/mixins/MixinInventoryCrafting.java
@@ -1,0 +1,36 @@
+package net.teamfruit.lazyae2patch.mixins;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * AE2-UEL hardcodes processing-pattern InventoryCrafting to 4x4 (16 slots),
+ * but Mass Assembler patterns can exceed that. Expand the backing list on demand.
+ */
+@Mixin(InventoryCrafting.class)
+public abstract class MixinInventoryCrafting {
+
+    @Shadow
+    @Final
+    @Mutable
+    private NonNullList<ItemStack> stackList;
+
+    @Inject(method = "setInventorySlotContents", at = @At("HEAD"))
+    private void lazyae2patch$expandForLargePatterns(int index, ItemStack stack, CallbackInfo ci) {
+        if (index >= 0 && index >= this.stackList.size()) {
+            NonNullList<ItemStack> expanded = NonNullList.withSize(index + 1, ItemStack.EMPTY);
+            for (int i = 0; i < this.stackList.size(); i++) {
+                expanded.set(i, this.stackList.get(i));
+            }
+            this.stackList = expanded;
+        }
+    }
+}

--- a/src/main/resources/mixins.lazyae2patch.json
+++ b/src/main/resources/mixins.lazyae2patch.json
@@ -8,7 +8,8 @@
     "MixinPacketInventoryAction",
     "MixinContainerInterfaceTerminal",
     "MixinTileBigAssemblerCore",
-    "MixinBlockBigAssembler"
+    "MixinBlockBigAssembler",
+    "MixinInventoryCrafting"
   ],
   "client": [
     "MixinContainerTile",


### PR DESCRIPTION
## Summary

- Add `MixinInventoryCrafting` that expands `InventoryCrafting.stackList` on demand when `setInventorySlotContents` is called with an out-of-bounds index
- Fixes `IndexOutOfBoundsException` (index 54 ≥ size 16) triggered by AE2-UEL hardcoding the crafting grid to 4×4 (16 slots) while Mass Assembler patterns can exceed that

## Root cause

`CraftingCPUCluster.executeCrafting` calls `FluidConvertingInventoryCrafting.setInventorySlotContents(54, ...)`, which delegates to `InventoryCrafting.setInventorySlotContents`. The backing `NonNullList` is fixed at 16 entries by AE2-UEL, so any index ≥ 16 throws.

## Fix

Inject at `HEAD` of `InventoryCrafting.setInventorySlotContents` and reallocate `stackList` to `index + 1` when the index would overflow. Existing entries are copied over.